### PR TITLE
Add ddns-update key support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ MAINTAINER Robin Smidsrød <robin@smidsrod.no>
 
 RUN apt-get -q -y update \
  && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" dist-upgrade \
- && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" install isc-dhcp-server man \
+ && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" install isc-dhcp-server man python3-minimal \
  && apt-get -q -y autoremove \
  && apt-get -q -y clean \
  && rm -rf /var/lib/apt/lists/*
 
 COPY util/my_init.py /sbin/my_init
 COPY util/entrypoint.sh /entrypoint.sh
+
+RUN rmdir /etc/dhcp/ddns-keys \
+ && ln -s /data/ddns-keys /etc/dhcp/ddns-keys
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
You appear to be routing things from the /data directory but the default ddns key location is in /etc/dhcp.  

This patch links from /data to /etc/dhcp.  It works properly but it may be better to change the configuration of the dhcp service to read straight from /data.  I just don't know how.
