### PR TITLE
entrypoint.sh: if interface was provided, wait for it to show up

### DIFF
--- a/util/entrypoint.sh
+++ b/util/entrypoint.sh
@@ -3,6 +3,12 @@ set -e
 
 # Single argument to command line is interface name
 if [ -n "$1" ]; then
+    # loop until interface is found, or we give up
+    NEXT_WAIT_TIME=1
+    until [ -e "/sys/class/net/$1" ] || [ $NEXT_WAIT_TIME -eq 4 ]; do
+        sleep $(( NEXT_WAIT_TIME++ ))
+        echo "Waiting for $1 to become available.... ${NEXT_WAIT_TIME}"
+    done
     if [ -e "/sys/class/net/$1" ]; then
         IFACE=$1
     fi


### PR DESCRIPTION
I'm using this with [pipework](https://github.com/jpetazzo/pipework), so
at launch time the interface in dhcpd container is not yet created.

`
docker run -itd --net=none --name dhcpd  -v "$(pwd)/data":/data  networkboot/dhcpd eth1
pipework   ${PARENT_IF}  -i eth1  dhcpd   10.2.0.254/24@10.2.0.1   @1000
`


