### PR TITLE
Fix #12: adapt run to local arch; use DATA_DIR if set

### DIFF
--- a/run
+++ b/run
@@ -7,7 +7,7 @@ if [ "${MACHINE_TYPE}" = 'x86_64' ]; then
 elif [ "${MACHINE_TYPE}" = armv7l ]; then
   MACHINE_TAG=':arm32v7'
 else
-  echo "Arhictecture not supported: $MACHINE_TYPE" 1>&2
+  echo "Architecture not supported: $MACHINE_TYPE" 1>&2
   exit 1
 fi
 

--- a/run
+++ b/run
@@ -1,5 +1,19 @@
 #!/bin/bash
-pushd $(dirname $0) >/dev/null
-data_dir="$(pwd)/data"
-docker run -ti --rm --net host -v "$data_dir":/data networkboot/dhcpd "$@"
-popd >/dev/null
+
+MACHINE_TYPE=`uname -m`
+
+if [ "${MACHINE_TYPE}" = 'x86_64' ]; then
+  MACHINE_TAG=
+elif [ "${MACHINE_TYPE}" = armv7l ]; then
+  MACHINE_TAG=':arm32v7'
+else
+  echo "Arhictecture not supported: $MACHINE_TYPE" 1>&2
+  exit 1
+fi
+
+if [ -z "$DATA_DIR" ]; then
+  DATA_DIR="$(pwd)/data"
+fi
+
+docker run -ti --rm --net host -v "$DATA_DIR":/data networkboot/dhcpd"${MACHINE_TAG}" "$@"
+

--- a/run
+++ b/run
@@ -15,5 +15,7 @@ if [ -z "$DATA_DIR" ]; then
   DATA_DIR="$(pwd)/data"
 fi
 
+cd "$(dirname "$0")" || exit 1	# bash prints a message if dir not found.
+
 docker run -ti --rm --net host -v "$DATA_DIR":/data "networkboot/dhcpd${MACHINE_TAG}" "$@"
 

--- a/run
+++ b/run
@@ -15,5 +15,5 @@ if [ -z "$DATA_DIR" ]; then
   DATA_DIR="$(pwd)/data"
 fi
 
-docker run -ti --rm --net host -v "$DATA_DIR":/data networkboot/dhcpd"${MACHINE_TAG}" "$@"
+docker run -ti --rm --net host -v "$DATA_DIR":/data "networkboot/dhcpd${MACHINE_TAG}" "$@"
 


### PR DESCRIPTION
Change #11 added support to `builld` for ARM; this pull request does the same for the run script. Because the data directory may be someplace like `/opt/dhcpd/data`, this change also adds support for setting DATA_DIR in the environment. If not set, script works as before. I would make two commits, but every line was touched by the first change. Let me know if you'd like me to split up.