### PR TITLE
Remove need for ARM-specific build script and Dockerfile

### DIFF
--- a/build
+++ b/build
@@ -1,10 +1,2 @@
 #!/bin/bash
-MACHINE_TYPE=`uname -m`
-
-if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-  docker build -t networkboot/dhcpd "$@" $(dirname $0)
-elif [ ${MACHINE_TYPE} == 'armv7l' ]; then
-  docker build -t networkboot/dhcpd:arm32v7 "$@" $(dirname $0) -f Dockerfile.arm32v7
-else 
-  echo "Your machine type $MACHINE_TYPE is currently not supported" >&2
-fi
+docker build -t networkboot/dhcpd "$@" $(dirname $0)


### PR DESCRIPTION
Since dumb-init is bundled in Ubuntu 18.04, there is no longer any need for a custom Dockerfile with an ARM-specific version of dumb-init.