### PR TITLE
Remove dpkg excludes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -q -y update \
  && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" install apt-utils \
+ && rm /etc/dpkg/dpkg.cfg.d/excludes \
  && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" install dumb-init isc-dhcp-server man \
  && apt-get -q -y autoremove \
  && apt-get -q -y clean \


### PR DESCRIPTION
Remove /etc/dpkg/dpkg.cfg.d/excludes for installing man pages.