### PR TITLE
allow passing multiple listening interfaces to the container

### DIFF
--- a/build
+++ b/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build -t networkboot/dhcpd "$@" $(dirname $0)
+docker build -t formlabs/dhcpd "$@" $(dirname $0)

--- a/util/entrypoint.sh
+++ b/util/entrypoint.sh
@@ -46,6 +46,4 @@ if perl -e '($id,$name)=@ARGV;$short=substr $id,0,length $name;exit 1 if $name n
     echo "You must add the 'docker run' option '--net=host' if you want to provide DHCP service to the host network."
 fi
 
-echo "Hello!!!!!"
-
 $run /usr/sbin/dhcpd -4 -f -d --no-pid -cf "$data_dir/dhcpd.conf" -lf "$data_dir/dhcpd.leases" "$@"

--- a/util/entrypoint.sh
+++ b/util/entrypoint.sh
@@ -11,66 +11,41 @@ else
     run="exec /usr/bin/dumb-init --"
 fi
 
-# Single argument to command line is interface name
-if [ $# -eq 1 -a -n "$1" ]; then
-    # skip wait-for-interface behavior if found in path
-    if ! which "$1" >/dev/null; then
-        # loop until interface is found, or we give up
-        NEXT_WAIT_TIME=1
-        until [ -e "/sys/class/net/$1" ] || [ $NEXT_WAIT_TIME -eq 4 ]; do
-            sleep $(( NEXT_WAIT_TIME++ ))
-            echo "Waiting for interface '$1' to become available... ${NEXT_WAIT_TIME}"
-        done
-        if [ -e "/sys/class/net/$1" ]; then
-            IFACE="$1"
-        fi
-    fi
+# Run dhcpd for specified interface or all interfaces
+data_dir="/data"
+if [ ! -d "$data_dir" ]; then
+    echo "Please ensure '$data_dir' folder is available."
+    echo 'If you just want to keep your configuration in "data/", add -v "$(pwd)/data:/data" to the docker run command line.'
+    exit 1
 fi
 
-# No arguments mean all interfaces
-if [ -z "$1" ]; then
-    IFACE=" "
+dhcpd_conf="$data_dir/dhcpd.conf"
+if [ ! -r "$dhcpd_conf" ]; then
+    echo "Please ensure '$dhcpd_conf' exists and is readable."
+    echo "Run the container with arguments 'man dhcpd.conf' if you need help with creating the configuration."
+    exit 1
 fi
 
-if [ -n "$IFACE" ]; then
-    # Run dhcpd for specified interface or all interfaces
-
-    data_dir="/data"
-    if [ ! -d "$data_dir" ]; then
-        echo "Please ensure '$data_dir' folder is available."
-        echo 'If you just want to keep your configuration in "data/", add -v "$(pwd)/data:/data" to the docker run command line.'
-        exit 1
-    fi
-
-    dhcpd_conf="$data_dir/dhcpd.conf"
-    if [ ! -r "$dhcpd_conf" ]; then
-        echo "Please ensure '$dhcpd_conf' exists and is readable."
-        echo "Run the container with arguments 'man dhcpd.conf' if you need help with creating the configuration."
-        exit 1
-    fi
-
-    uid=$(stat -c%u "$data_dir")
-    gid=$(stat -c%g "$data_dir")
-    if [ $gid -ne 0 ]; then
-        groupmod -g $gid dhcpd
-    fi
-    if [ $uid -ne 0 ]; then
-        usermod -u $uid dhcpd
-    fi
-
-    [ -e "$data_dir/dhcpd.leases" ] || touch "$data_dir/dhcpd.leases"
-    chown dhcpd:dhcpd "$data_dir/dhcpd.leases"
-    if [ -e "$data_dir/dhcpd.leases~" ]; then
-        chown dhcpd:dhcpd "$data_dir/dhcpd.leases~"
-    fi
-
-    container_id=$(grep docker /proc/self/cgroup | sort -n | head -n 1 | cut -d: -f3 | cut -d/ -f3)
-    if perl -e '($id,$name)=@ARGV;$short=substr $id,0,length $name;exit 1 if $name ne $short;exit 0' $container_id $HOSTNAME; then
-        echo "You must add the 'docker run' option '--net=host' if you want to provide DHCP service to the host network."
-    fi
-
-    $run /usr/sbin/dhcpd -4 -f -d --no-pid -cf "$data_dir/dhcpd.conf" -lf "$data_dir/dhcpd.leases" $IFACE
-else
-    # Run another binary
-    $run "$@"
+uid=$(stat -c%u "$data_dir")
+gid=$(stat -c%g "$data_dir")
+if [ $gid -ne 0 ]; then
+    groupmod -g $gid dhcpd
 fi
+if [ $uid -ne 0 ]; then
+    usermod -u $uid dhcpd
+fi
+
+[ -e "$data_dir/dhcpd.leases" ] || touch "$data_dir/dhcpd.leases"
+chown dhcpd:dhcpd "$data_dir/dhcpd.leases"
+if [ -e "$data_dir/dhcpd.leases~" ]; then
+    chown dhcpd:dhcpd "$data_dir/dhcpd.leases~"
+fi
+
+container_id=$(grep docker /proc/self/cgroup | sort -n | head -n 1 | cut -d: -f3 | cut -d/ -f3)
+if perl -e '($id,$name)=@ARGV;$short=substr $id,0,length $name;exit 1 if $name ne $short;exit 0' $container_id $HOSTNAME; then
+    echo "You must add the 'docker run' option '--net=host' if you want to provide DHCP service to the host network."
+fi
+
+echo "Hello!!!!!"
+
+$run /usr/sbin/dhcpd -4 -f -d --no-pid -cf "$data_dir/dhcpd.conf" -lf "$data_dir/dhcpd.leases" "$@"


### PR DESCRIPTION
This pull request shows how to specify multiple interfaces to listen to. I've removed some of the error checking code in order to simplify the handling of the `$@` argument, and hence the bulk of the change is the left indent by one. In this case, it just assumes that the interfaces are available (or not, in which case the server complains but will serve on the other available interfaces).