### PR TITLE
[33] Make dhcpd process run as the dhcpd user and group

### DIFF
--- a/util/entrypoint.sh
+++ b/util/entrypoint.sh
@@ -51,12 +51,8 @@ if [ -n "$IFACE" ]; then
 
     uid=$(stat -c%u "$data_dir")
     gid=$(stat -c%g "$data_dir")
-    if [ $gid -ne 0 ]; then
-        groupmod -g $gid dhcpd
-    fi
-    if [ $uid -ne 0 ]; then
-        usermod -u $uid dhcpd
-    fi
+    groupmod -og $gid dhcpd
+    usermod -ou $uid dhcpd
 
     [ -e "$data_dir/dhcpd.leases" ] || touch "$data_dir/dhcpd.leases"
     chown dhcpd:dhcpd "$data_dir/dhcpd.leases"
@@ -69,7 +65,7 @@ if [ -n "$IFACE" ]; then
         echo "You must add the 'docker run' option '--net=host' if you want to provide DHCP service to the host network."
     fi
 
-    $run /usr/sbin/dhcpd -$DHCPD_PROTOCOL -f -d --no-pid -cf "$data_dir/dhcpd.conf" -lf "$data_dir/dhcpd.leases" $IFACE
+    $run /usr/sbin/dhcpd -$DHCPD_PROTOCOL -f -d --no-pid -cf "$data_dir/dhcpd.conf" -lf "$data_dir/dhcpd.leases" -user dhcpd -group dhcpd $IFACE
 else
     # Run another binary
     $run "$@"


### PR DESCRIPTION
Fixes issue #33.

Make the `dhcpd` process run as user and group `dhcpd`.

Additional Informations
---

Prior to running the process, the entrypoint script make sure those user & group have the same id as the user & group owning `/data`.

If `/data` is owned by the `root` user (or group), the `dhcpd` user (or group) will be modified to have UID 0 (or GID). This is allowed for two users (or groups) to share the same id, this is the purpose of the `-o` flag of `usermod` (or `groupmod).

Tests Cases
---

- [x] `/data` owned by `666:666`
- [x] `/data` owned by `0:0`
- [ ] `/data` owned by `0:666`

Test modus operandi
---

```shell
cd $(mktemp -d)
mkdir data
cat > data/dhcpd.conf <<EOF
subnet 192.168.1.0 netmask 255.255.255.0 {
    option routers                  192.168.1.254;
    option subnet-mask              255.255.255.0;
    option domain-name-servers      1.1.1.1;
    range                           192.168.1.1 192.168.1.253;
}
EOF
sudo chown --recursive 666:666 data # or other owner
docker run -d --rm --name dhcpd --init --net host -v "$(pwd)/data":/data networkboot/dhcpd:issue-33
sleep 10
find . -exec ls -l {} \;
docker exec dhcpd ps -ef
docker stop dhcpd
cd
sudo rm -rf -- $OLDPWD #BEWARE
```

Tests Results
---

### 666:666
```
$ find . -exec ls -l {} \;
total 4
drwxrwxr-x 2 666 666 4096 Jul  5 21:49 data
total 8
-rw-rw-r-- 1 666 666 255 Jul  5 21:48 dhcpd.conf
-rw-r--r-- 1 666 666 277 Jul  5 21:49 dhcpd.leases
-rw-r--r-- 1 666 666   0 Jul  5 21:49 dhcpd.leases~
-rw-r--r-- 1 666 666 277 Jul  5 21:49 ./data/dhcpd.leases
-rw-rw-r-- 1 666 666 255 Jul  5 21:48 ./data/dhcpd.conf
-rw-r--r-- 1 666 666 0 Jul  5 21:49 ./data/dhcpd.leases~
yscialom@ubuntu:/tmp/tmp.TcaQshAxmH$ docker exec dhcpd ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 21:49 ?        00:00:00 /sbin/docker-init -- /entrypoint.sh
root           6       1  0 21:49 ?        00:00:00 /usr/bin/dumb-init -- /usr/sbin/dhcpd -4 -f -d --no-pid -cf /data/dhcpd.conf -lf /data/dhcpd.leases -user dhcpd -group dhcpd
dhcpd         31       6  0 21:49 ?        00:00:00 /usr/sbin/dhcpd -4 -f -d --no-pid -cf /data/dhcpd.conf -lf /data/dhcpd.leases -user dhcpd -group dhcpd
root          35       0  0 21:49 ?        00:00:00 ps -ef
```

### 0:0
```
$ find . -exec ls -l {} \;
total 4
drwxrwxr-x 2 root root 4096 Jul  5 21:33 data
total 8
-rw-rw-r-- 1 root root 255 Jul  5 21:28 dhcpd.conf
-rw-r--r-- 1 root root 280 Jul  5 21:33 dhcpd.leases
-rw-r--r-- 1 root root   0 Jul  5 21:33 dhcpd.leases~
-rw-r--r-- 1 root root 280 Jul  5 21:33 ./data/dhcpd.leases
-rw-rw-r-- 1 root root 255 Jul  5 21:28 ./data/dhcpd.conf
-rw-r--r-- 1 root root 0 Jul  5 21:33 ./data/dhcpd.leases~
$ docker exec dhcpd ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 21:47 ?        00:00:00 /sbin/docker-init -- /entrypoint.sh
root           6       1  0 21:47 ?        00:00:00 /usr/bin/dumb-init -- /usr/sbin/dhcpd -4 -f -d --no-pid -cf /data/dhcpd.conf -lf /data/dhcpd.leases -user dhcpd -group dhcpd
root          31       6  0 21:47 ?        00:00:00 /usr/sbin/dhcpd -4 -f -d --no-pid -cf /data/dhcpd.conf -lf /data/dhcpd.leases -user dhcpd -group dhcpd
root          35       0  0 21:47 ?        00:00:00 ps -ef
```


### 0:666
```
$ find . -exec ls -l {} \;
total 4
drwxrwxr-x 2 root 666 4096 Jul  5 21:51 data
total 8
-rw-rw-r-- 1 root  666 255 Jul  5 21:50 dhcpd.conf
-rw-r--r-- 1 root root 280 Jul  5 21:51 dhcpd.leases
-rw-r--r-- 1 root  666   0 Jul  5 21:51 dhcpd.leases~
-rw-r--r-- 1 root root 280 Jul  5 21:51 ./data/dhcpd.leases
-rw-rw-r-- 1 root 666 255 Jul  5 21:50 ./data/dhcpd.conf
-rw-r--r-- 1 root 666 0 Jul  5 21:51 ./data/dhcpd.leases~
$ docker exec dhcpd ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 21:51 ?        00:00:00 /sbin/docker-init -- /entrypoint.sh
root           6       1  0 21:51 ?        00:00:00 /usr/bin/dumb-init -- /usr/sbin/dhcpd -4 -f -d --no-pid -cf /data/dhcpd.conf -lf /data/dhcpd.leases -user dhcpd -group dhcpd
root          31       6  0 21:51 ?        00:00:00 /usr/sbin/dhcpd -4 -f -d --no-pid -cf /data/dhcpd.conf -lf /data/dhcpd.leases -user dhcpd -group dhcpd
root          35       0  0 21:51 ?        00:00:00 ps -ef
```

The mixed case is not passing. It looks like an issue with `dhcpd` itself. Opinions?